### PR TITLE
Aggiornata govpay-bom 1.1.3 / govpay-common 1.1.2, aggiunto job SBOM …

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,18 +1,10 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Java CI with Maven
 
 on:
   push:
     branches: [ "main" ]
     tags:
-      - '*'  # Trigger per tutti i tag
+      - '*'
   pull_request:
     branches: [ "main" ]
 
@@ -22,22 +14,26 @@ permissions:
   actions: write
 
 jobs:
-  build:
 
+  # ── Build, Test, Quality ─────────────────────────────────────────────
+  build:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
       with:
-        fetch-depth: 0  # Clona tutta la history Git
+        fetch-depth: 0
+
     - name: Set timezone to Europe/Rome
       run: sudo timedatectl set-timezone Europe/Rome
+
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+
     - name: Check NVD_API_KEY
       run: |
         if [ -z "$NVD_API_KEY" ]; then
@@ -47,6 +43,7 @@ jobs:
         fi
       env:
         NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+
     - name: Check OSS_INDEX_USER
       run: |
         if [ -z "$OSS_INDEX_USER" ]; then
@@ -56,6 +53,7 @@ jobs:
         fi
       env:
         OSS_INDEX_USER: ${{ vars.OSS_INDEX_USER }}
+
     - name: Check OSS_INDEX_PASSWORD
       run: |
         if [ -z "$OSS_INDEX_PASSWORD" ]; then
@@ -80,7 +78,7 @@ jobs:
           ${{ runner.os }}-owasp-
 
     - name: Build with Maven
-      run: mvn clean install -P jar -Dspring.profiles.active=test -Duser.timezone=Europe/Rome -DnvdApiKey=$NVD_API_KEY -DossIndexUsername=$OSS_INDEX_USER -DossIndexPassword=$OSS_INDEX_PASSWORD -DdataDirectory=.dependency-check/data -Dowasp.format=ALL -Dowasp.output.dir=./dependency-check-report $NOUPDATE_FLAG
+      run: mvn clean install -Dspring.profiles.active=test -Duser.timezone=Europe/Rome -DnvdApiKey=$NVD_API_KEY -DossIndexUsername=$OSS_INDEX_USER -DossIndexPassword=$OSS_INDEX_PASSWORD -DdataDirectory=.dependency-check/data -Dowasp.format=ALL -Dowasp.output.dir=./dependency-check-report $NOUPDATE_FLAG
       env:
         NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         OSS_INDEX_USER: ${{ vars.OSS_INDEX_USER }}
@@ -161,10 +159,57 @@ jobs:
         --lockfile
         ./pom.xml
 
+  # ── SBOM CycloneDX ───────────────────────────────────────────────────
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: >-
+      vars.DISABLE_SBOM_JOB != 'true' &&
+      (github.event_name == 'push' &&
+       (github.ref_name == 'main' || github.ref_type == 'tag' || vars.FORCE_SBOM_JOB == 'true'))
+    continue-on-error: ${{ vars.FORCE_SBOM_JOB == 'true' && github.ref_type != 'tag' && github.ref_name != 'main' }}
+    env:
+      SBOM_CYCLONEDX_PLUGIN_VERSION: '2.9.1'   # ← adegua al valore reale
+      SBOM_CYCLONEDX_SCHEMA_VERSION: '1.6'     # ← adegua al valore reale
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Generate SBOM (CycloneDX json + xml)
+        run: |
+          mkdir -p sbom/cyclonedx
+          echo "Generazione SBOM CycloneDX (json + xml) ..."
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${SBOM_CYCLONEDX_PLUGIN_VERSION}:makeAggregateBom \
+            -DoutputDirectory=sbom/cyclonedx \
+            -DoutputName=bom.cdx \
+            -DoutputFormat=all \
+            -DschemaVersion=${SBOM_CYCLONEDX_SCHEMA_VERSION} \
+            -DskipNotDeployed=false \
+            -DincludeTestScope=false
+          ls -la sbom/cyclonedx/
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-report
+          path: sbom/
+          retention-days: 30
+
+  # ── GitHub Release (solo tag) ────────────────────────────────────────
   release:
     runs-on: ubuntu-latest
-    needs: [ build, osv-scan ]
-    if: startsWith(github.ref, 'refs/tags/')  # Esegui solo per i tag
+    needs: [ build, osv-scan, sbom ]
+    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
     - name: Checkout code
@@ -190,19 +235,26 @@ jobs:
         name: OSV Scanner SARIF file
         path: reports/osv/
 
+    - name: Download SBOM
+      uses: actions/download-artifact@v7
+      with:
+        name: sbom-report
+        path: reports/sbom/
+
     - name: Rename JAR with tag version
       run: |
         cp jar/govpay-aca-batch.jar jar/govpay-aca-batch-${{ github.ref_name }}.jar
 
     - name: Zip SQL files
       run: |
+        mkdir -p target
         cd src/main/resources
         zip -r ../../../target/sql.zip sql
         cd ../../../
 
     - name: Assemble reports ZIP
       run: |
-        mkdir -p reports/owasp reports/jacoco reports/osv
+        mkdir -p reports/owasp reports/jacoco reports/osv reports/sbom
 
         # OWASP e JaCoCo dall'artifact build
         cp jar/dependency-check-report.html reports/owasp/ 2>/dev/null || true
@@ -227,6 +279,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  # ── Docker build & push (solo tag, dopo release) ─────────────────────
   docker:
     runs-on: ubuntu-latest
     needs: release

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2026-05-05  Giuliano Pintori <pintori@link.it>
+
+	* [Build]
+	Aggiornata govpay-bom alla versione 1.1.3.
+	Aggiornata govpay-common alla versione 1.1.2.
+
+	* [GDE]
+	Implementato il nuovo metodo astratto AbstractGdeService#getConfigurazioneComponente
+	(introdotto da govpay-common 1.1.2) per risolvere la GdeInterfaccia per ComponenteEvento
+	dal Giornale di configurazione.
+
+	* [Test]
+	Rinominata l'entity name del test ApplicazioneEntity in "TestApplicazioneEntity" per
+	evitare la collisione con la nuova it.govpay.common.entity.ApplicazioneEntity introdotta
+	da govpay-common 1.1.2.
+
+	* [Pipeline]
+	Aggiunto job SBOM CycloneDX (json + xml) tramite cyclonedx-maven-plugin 2.9.1, schema 1.6.
+	L'SBOM viene pubblicato come artifact (sbom-report) e incluso nello ZIP dei report di release.
+	Il job e' disattivabile con vars.DISABLE_SBOM_JOB e forzabile con vars.FORCE_SBOM_JOB.
+	Allineata la pipeline alla struttura di govpay-fdr-batch (rimosso -P jar dal build, profilo
+	jar resta attivo by default; aggiunti separatori di sezione nel workflow).
+	Aggiunto mkdir -p target prima della creazione di sql.zip per evitare il fallimento dello
+	step sul runner di release (dove non viene eseguito mvn install).
+
 2026-04-23  Giuliano Pintori <pintori@link.it>
 
 	* [Pipeline]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.gov4j.govpay</groupId>
 		<artifactId>govpay-bom</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>1.1.3</version>
 		<relativePath>../govpay-bom</relativePath>
 	</parent>
 	<groupId>it.govpay.gpd</groupId>
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.gov4j.govpay</groupId>
 			<artifactId>govpay-common</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.2</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/it/govpay/gpd/gde/service/GdeService.java
+++ b/src/main/java/it/govpay/gpd/gde/service/GdeService.java
@@ -17,9 +17,12 @@ import org.springframework.web.client.RestClientException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.govpay.common.client.gde.HttpDataHolder;
+import it.govpay.common.configurazione.model.GdeInterfaccia;
+import it.govpay.common.configurazione.model.Giornale;
 import it.govpay.common.configurazione.service.ConfigurazioneService;
 import it.govpay.common.gde.AbstractGdeService;
 import it.govpay.common.gde.GdeEventInfo;
+import it.govpay.gde.client.beans.ComponenteEvento;
 import it.govpay.gde.client.beans.Header;
 import it.govpay.gde.client.beans.NuovoEvento;
 import it.govpay.gpd.client.beans.PaymentPositionModel;
@@ -65,6 +68,24 @@ public class GdeService extends AbstractGdeService {
 	protected NuovoEvento convertToGdeEvent(GdeEventInfo eventInfo) {
 		throw new UnsupportedOperationException(
 				"GdeService usa sendEventAsync(NuovoEvento) direttamente, non il pattern GdeEventInfo");
+	}
+
+	@Override
+	protected GdeInterfaccia getConfigurazioneComponente(ComponenteEvento componente, Giornale giornale) {
+		if (componente == null || giornale == null) {
+			return null;
+		}
+		return switch (componente) {
+			case API_PAGOPA -> giornale.getApiPagoPA();
+			case API_ENTE -> giornale.getApiEnte();
+			case API_PAGAMENTO -> giornale.getApiPagamento();
+			case API_RAGIONERIA -> giornale.getApiRagioneria();
+			case API_BACKOFFICE -> giornale.getApiBackoffice();
+			case API_PENDENZE -> giornale.getApiPendenze();
+			case API_BACKEND_IO -> giornale.getApiBackendIO();
+			case API_MAGGIOLI_JPPA -> giornale.getApiMaggioliJPPA();
+			default -> null;
+		};
 	}
 
 	@Override

--- a/src/test/java/it/govpay/gpd/test/GdeServiceTest.java
+++ b/src/test/java/it/govpay/gpd/test/GdeServiceTest.java
@@ -1,6 +1,8 @@
 package it.govpay.gpd.test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,7 +25,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import it.govpay.common.configurazione.model.GdeInterfaccia;
+import it.govpay.common.configurazione.model.Giornale;
 import it.govpay.common.configurazione.service.ConfigurazioneService;
+import it.govpay.gde.client.beans.ComponenteEvento;
 import it.govpay.gde.client.beans.NuovoEvento;
 import it.govpay.gpd.client.beans.PaymentPositionModel;
 import it.govpay.gpd.entity.VersamentoGpdEntity;
@@ -83,5 +90,57 @@ class GdeServiceTest {
 		org.junit.jupiter.api.Assertions.assertTrue(
 				capturedUrl != null && !capturedUrl.contains("fakehost"),
 				"La URL non deve contenere un basePath reale quando getGpdBasePath fallisce");
+	}
+
+	@Test
+	@DisplayName("getConfigurazioneComponente - componente null restituisce null")
+	void getConfigurazioneComponente_ComponenteNull() {
+		GdeInterfaccia result = ReflectionTestUtils.invokeMethod(
+				gdeService, "getConfigurazioneComponente", null, new Giornale());
+		assertNull(result);
+	}
+
+	@Test
+	@DisplayName("getConfigurazioneComponente - giornale null restituisce null")
+	void getConfigurazioneComponente_GiornaleNull() {
+		GdeInterfaccia result = ReflectionTestUtils.invokeMethod(
+				gdeService, "getConfigurazioneComponente", ComponenteEvento.API_PAGOPA, null);
+		assertNull(result);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = ComponenteEvento.class, names = {
+			"API_PAGOPA", "API_ENTE", "API_PAGAMENTO", "API_RAGIONERIA",
+			"API_BACKOFFICE", "API_PENDENZE", "API_BACKEND_IO", "API_MAGGIOLI_JPPA" })
+	@DisplayName("getConfigurazioneComponente - mappa ogni componente alla GdeInterfaccia del Giornale")
+	void getConfigurazioneComponente_MappaturaComponenti(ComponenteEvento componente) {
+		Giornale giornale = new Giornale();
+		GdeInterfaccia atteso = new GdeInterfaccia();
+		switch (componente) {
+			case API_PAGOPA -> giornale.setApiPagoPA(atteso);
+			case API_ENTE -> giornale.setApiEnte(atteso);
+			case API_PAGAMENTO -> giornale.setApiPagamento(atteso);
+			case API_RAGIONERIA -> giornale.setApiRagioneria(atteso);
+			case API_BACKOFFICE -> giornale.setApiBackoffice(atteso);
+			case API_PENDENZE -> giornale.setApiPendenze(atteso);
+			case API_BACKEND_IO -> giornale.setApiBackendIO(atteso);
+			case API_MAGGIOLI_JPPA -> giornale.setApiMaggioliJPPA(atteso);
+			default -> { /* non raggiungibile per i valori dell'EnumSource */ }
+		}
+
+		GdeInterfaccia result = ReflectionTestUtils.invokeMethod(
+				gdeService, "getConfigurazioneComponente", componente, giornale);
+
+		assertSame(atteso, result);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = ComponenteEvento.class, names = {
+			"API_SECIM", "API_MYPIVOT", "API_GOVPAY", "API_HYPERSIC_APK", "API_USER", "GOVPAY" })
+	@DisplayName("getConfigurazioneComponente - componenti non gestiti restituiscono null")
+	void getConfigurazioneComponente_DefaultBranch(ComponenteEvento componente) {
+		GdeInterfaccia result = ReflectionTestUtils.invokeMethod(
+				gdeService, "getConfigurazioneComponente", componente, new Giornale());
+		assertNull(result);
 	}
 }

--- a/src/test/java/it/govpay/gpd/test/entity/ApplicazioneEntity.java
+++ b/src/test/java/it/govpay/gpd/test/entity/ApplicazioneEntity.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Entity
+@Entity(name = "TestApplicazioneEntity")
 @Table(name = "applicazioni")
 public class ApplicazioneEntity {
 


### PR DESCRIPTION
…e allineamento pipeline.

- pom.xml: parent govpay-bom 1.1.3, govpay-common 1.1.2
- GdeService: implementato il nuovo metodo astratto getConfigurazioneComponente introdotto in AbstractGdeService da govpay-common 1.1.2
- Test: rinominata entity name del test ApplicazioneEntity in TestApplicazioneEntity per evitare la collisione con la nuova it.govpay.common.entity.ApplicazioneEntity
- Pipeline: aggiunto job SBOM CycloneDX (json + xml) tramite cyclonedx-maven-plugin 2.9.1, SBOM incluso nello ZIP dei report di release; allineamento alla struttura di govpay-fdr-batch (rimosso -P jar, separatori di sezione); aggiunto mkdir -p target nello step Zip SQL files (allineamento a govpay-iban-batch)
- ChangeLog aggiornato